### PR TITLE
Generate type casting code in all cases

### DIFF
--- a/data/generator/sfDoctrineRestGenerator/default/parts/configureFields.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configureFields.php
@@ -13,7 +13,7 @@ $specific_configuration_directives = false;
 
 foreach ($fields as $field => $configuration)
 {
-  if (isset($configuration['date_format']) || isset($configuration['tag_name']))
+  if (isset($configuration['date_format']) || isset($configuration['tag_name']) || isset($configuration['type']))
   {
     $specific_configuration_directives = true;
     continue;


### PR DESCRIPTION
Even if there are no date_format or tag_name field configuration
directives

Fixes xavierlacot/sfDoctrineRestGeneratorPlugin#25
