### PR TITLE
Use Class name instead of Alias name for Validators

### DIFF
--- a/lib/generator/sfDoctrineRestGenerator.class.php
+++ b/lib/generator/sfDoctrineRestGenerator.class.php
@@ -741,7 +741,7 @@ class sfDoctrineRestGenerator extends sfGenerator
 
     if ($column->isForeignKey())
     {
-      $options[] = sprintf('\'model\' => Doctrine_Core::getTable('.$model.')->getRelation(\'%s\')->getAlias()', $column->getRelationKey('alias'));
+      $options[] = sprintf('\'model\' => Doctrine_Core::getTable('.$model.')->getRelation(\'%s\')->getTable()->getComponentName()', $column->getRelationKey('alias'));
     }
     else if ($column->isPrimaryKey())
     {


### PR DESCRIPTION
Fix bug in which Doctrine couldn't find table 'AliasName'
