### PR TITLE
Allow custom specified function for object_additional_fields

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -493,6 +493,31 @@ generator generates this code as comments):
       $this->objects[$item] = $array;
     }
 
+It's also possible to specify which method should be called to add the field:
+
+```yaml
+config:
+  get:
+    object_additional_fields:
+      is_deleted: additionalFieldIsDeleted
+```
+
+The specified function should have this signature:
+```php
+function additionalFieldIsDeleted(array $object, array $parameters): mixed
+{
+  // $object contains the object as it currently is formatted
+  // $parameters contains the request parameters from this API call
+  // return the value you'd like field "is_deleted" to have
+}
+```
+
+and the specified function will be called in this way:
+```php
+// in formatObjects:
+$this->objects[$key]['is_deleted'] = $this->additionalFieldIsDeleted($this->objects[$key], $parameters);
+```
+
 
 #### pagination_enabled
 

--- a/data/generator/sfDoctrineRestGenerator/default/parts/formatObjects.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/formatObjects.php
@@ -10,9 +10,14 @@
 
     foreach ($this->objects as $key => $object)
     {
-<?php foreach ($this->configuration->getValue('get.object_additional_fields') as $field): ?>
+<?php   foreach ($this->configuration->getValue('get.object_additional_fields') as $idx => $field): ?>
+<?php     if (is_numeric($idx)): ?>
       $this->embedAdditional<?php echo $field ?>($key, $params);
-<?php endforeach; ?>
+<?php       list($key, $function) = array(key($field), current($field)); ?>
+<?php     else: ?>
+      $this->objects[$key][<?php echo var_export($idx, true); ?>] = $this-><?php echo $field; ?>($object, $params);
+<?php     endif; ?>
+<?php   endforeach; ?>
     }
 <?php endif; ?>
 <?php foreach ($this->configuration->getValue('get.global_additional_fields') as $field): ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/setFieldVisibility.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/setFieldVisibility.php
@@ -10,7 +10,13 @@
 $display = $this->configuration->getValue('get.display');
 $hide = $this->configuration->getValue('get.hide');
 $embed_relations = $this->configuration->getValue('get.embed_relations');
-$object_additional_fields = $this->configuration->getValue('get.object_additional_fields');
+$additional_fields = $this->configuration->getValue('get.object_additional_fields');
+$object_additional_fields = array_map(function($key, $value) {
+    if (is_numeric($key)) {
+        return $value;
+    }
+    return $key;
+}, array_keys($additional_fields), array_values($additional_fields));
 ?><?php if (count($display) > 0): ?>
 <?php if (count($hide) > 0): ?>
     $accepted_keys = <?php echo var_export(array_flip(array_merge(array_diff($display, $hide), $embed_relations, $embed_relations_custom, $object_additional_fields)), true);?>;


### PR DESCRIPTION
This is useful for embedding `snake_case` fields while keeping the code follow PSR-2 guidelines